### PR TITLE
chore(package): deprecate in favor of codetech/laravel-vendus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Vendus Api
 
+> [!WARNING]
+> **This package is deprecated and no longer maintained.** Its HTTP client was absorbed into [codetech/laravel-vendus](https://github.com/CodeTechAgency/laravel-vendus) v2 (as `CodeTech\Vendus\Http\VendusApi`, built on Laravel's HTTP client). Use that package instead. Existing installs keep working, but no further releases will be made.
+
 PHP library for implementing the Vendus API.
 
 [![Latest version](https://img.shields.io/github/release/CodeTechAgency/vendus-api?style=flat-square)](https://github.com/CodeTechAgency/vendus-api/releases)

--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,6 @@
     }
   },
   "minimum-stability": "dev",
-  "prefer-stable": true
+  "prefer-stable": true,
+  "abandoned": "codetech/laravel-vendus"
 }


### PR DESCRIPTION
## Description

laravel-vendus v2.0.0 has shipped with the HTTP client absorbed internally (`CodeTech\Vendus\Http\VendusApi`), so this package is being retired per the plan in #3:

- `"abandoned": "codetech/laravel-vendus"` in composer.json — Composer will warn installers and suggest the replacement once this reaches Packagist via the final tag
- Deprecation warning at the top of the README pointing to laravel-vendus

After merge, the remaining #3 steps: tag a final patch release (v1.1.2), mark abandoned on Packagist (maintainer web UI), and archive this repository.

Refs #3
